### PR TITLE
[BREQ 951] Fixed missing spaces in panels and increased interval for irate

### DIFF
--- a/docs/grafana-graphs-alerts.md
+++ b/docs/grafana-graphs-alerts.md
@@ -43,6 +43,8 @@ click on `Save` button
 * Click save button (4th symbol) on top right corner and save it.
 
 ## Example Queries
+**Note**: Time period for any query using irate function must be atleast more than twice the
+`scrape_interval`.
 
 ### CPU Idle
 * **Query:** (avg by (instance) (irate(node_cpu_seconds_total{job="node",mode="idle"}[5m])) * 100)

--- a/docs/grafana-prometheus-config.md
+++ b/docs/grafana-prometheus-config.md
@@ -29,6 +29,13 @@ open `/etc/kolla/grafana/grafana.ini` and put `domain = <api_interface_address>`
 the servers on which grafana containers are running and restart containers using
 `docker restart grafana`.
 
+## Prometheus Scrape interval
+Scrape interval is time period after which an exporter collects data. Lower scrape interval can
+put stress on resources. By default it collects data after every one minute. For changing
+`scrape_interval`, open `/etc/kolla/prometheus-server/prometheus.yml`. Change the value of
+`scrape_interval` under `global` and under `scrape_configs` if any of the exporter has
+`scrape_interval` variable defined.
+
 
 ## TLS Configuration
 If tls is enabled in your deployment then add `verify: false` under `default` in

--- a/voithos/lib/files/grafana/node_config.json
+++ b/voithos/lib/files/grafana/node_config.json
@@ -37,7 +37,7 @@
                             "query": {
                                 "params": [
                                     "A",
-                                    "5m",
+                                    "15m",
                                     "now"
                                 ]
                             },
@@ -263,7 +263,7 @@
                             "query": {
                                 "params": [
                                     "A",
-                                    "5m",
+                                    "15m",
                                     "now"
                                 ]
                             },
@@ -487,7 +487,7 @@
                             "query": {
                                 "params": [
                                     "A",
-                                    "5m",
+                                    "15m",
                                     "now"
                                 ]
                             },
@@ -622,7 +622,7 @@
                             "query": {
                                 "params": [
                                     "A",
-                                    "5m",
+                                    "15m",
                                     "now"
                                 ]
                             },
@@ -757,7 +757,7 @@
                             "query": {
                                 "params": [
                                     "A",
-                                    "5m",
+                                    "15m",
                                     "now"
                                 ]
                             },
@@ -820,7 +820,7 @@
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "(avg by (instance) (irate(node_cpu_seconds_total{job=\"node\",mode=\"idle\"}[30m])) * 100)",
+                        "expr": "(avg by (instance) (irate(node_cpu_seconds_total{job=\"node\",mode=\"idle\"}[31m])) * 100)",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -894,7 +894,7 @@
                             "query": {
                                 "params": [
                                     "A",
-                                    "5m",
+                                    "15m",
                                     "now"
                                 ]
                             },
@@ -953,7 +953,7 @@
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "irate((node_network_receive_bytes_total{device=~\"en.*\"}[30m]))",
+                        "expr": "irate((node_network_receive_bytes_total{device=~\"en.*\"}[31m]))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1027,7 +1027,7 @@
                             "query": {
                                 "params": [
                                     "A",
-                                    "5m",
+                                    "15m",
                                     "now"
                                 ]
                             },
@@ -1086,7 +1086,7 @@
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "irate((node_network_transmit_bytes_total{device=~\"en.*\"}[30m]))",
+                        "expr": "irate((node_network_transmit_bytes_total{device=~\"en.*\"}[31m]))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"

--- a/voithos/lib/files/grafana/node_config.json
+++ b/voithos/lib/files/grafana/node_config.json
@@ -86,7 +86,7 @@
                 },
                 "lines": true,
                 "linewidth": 2,
-                "nullPointMode": "null",
+                "nullPointMode": "connected",
                 "options": {
                     "dataLinks": []
                 },
@@ -183,7 +183,7 @@
                 },
                 "lines": true,
                 "linewidth": 2,
-                "nullPointMode": "null",
+                "nullPointMode": "connected",
                 "options": {
                     "dataLinks": []
                 },
@@ -312,7 +312,7 @@
                 },
                 "lines": true,
                 "linewidth": 2,
-                "nullPointMode": "null",
+                "nullPointMode": "connected",
                 "options": {
                     "dataLinks": []
                 },
@@ -409,7 +409,7 @@
                 },
                 "lines": true,
                 "linewidth": 2,
-                "nullPointMode": "null",
+                "nullPointMode": "connected",
                 "options": {
                     "dataLinks": []
                 },
@@ -536,7 +536,7 @@
                 },
                 "lines": true,
                 "linewidth": 2,
-                "nullPointMode": "null",
+                "nullPointMode": "connected",
                 "options": {
                     "dataLinks": []
                 },
@@ -671,7 +671,7 @@
                 },
                 "lines": true,
                 "linewidth": 2,
-                "nullPointMode": "null",
+                "nullPointMode": "connected",
                 "options": {
                     "dataLinks": []
                 },
@@ -806,7 +806,7 @@
                 },
                 "lines": true,
                 "linewidth": 2,
-                "nullPointMode": "null",
+                "nullPointMode": "connected",
                 "options": {
                     "dataLinks": []
                 },
@@ -820,7 +820,7 @@
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "(avg by (instance) (irate(node_cpu_seconds_total{job=\"node\",mode=\"idle\"}[5m])) * 100)",
+                        "expr": "(avg by (instance) (irate(node_cpu_seconds_total{job=\"node\",mode=\"idle\"}[30m])) * 100)",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -939,7 +939,7 @@
                 },
                 "lines": true,
                 "linewidth": 2,
-                "nullPointMode": "null",
+                "nullPointMode": "connected",
                 "options": {
                     "dataLinks": []
                 },
@@ -953,7 +953,7 @@
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "irate((node_network_receive_bytes_total{device=~\"en.*\"}[5m]))",
+                        "expr": "irate((node_network_receive_bytes_total{device=~\"en.*\"}[30m]))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"
@@ -1072,7 +1072,7 @@
                 },
                 "lines": true,
                 "linewidth": 2,
-                "nullPointMode": "null",
+                "nullPointMode": "connected",
                 "options": {
                     "dataLinks": []
                 },
@@ -1086,7 +1086,7 @@
                 "steppedLine": false,
                 "targets": [
                     {
-                        "expr": "irate((node_network_transmit_bytes_total{device=~\"en.*\"}[5m]))",
+                        "expr": "irate((node_network_transmit_bytes_total{device=~\"en.*\"}[30m]))",
                         "interval": "",
                         "legendFormat": "",
                         "refId": "A"


### PR DESCRIPTION
This PR makes changes required in voithos for #951.

**Irate Interval**
We are using `irate` method in three of our `Servers` dashboard panels. Irate method's output depends on last two data points. If we increase the prometheus server's scrape interval to 15 minutes then time period for irate method should be large enough to have atleast two data points in that span. It's increased to 31 minutes. Changing it to something more that 31 won't make any difference.

**Empty Spaces In Panels**
When we increase the scrape interval to more than 5 minutes, we see breaks in graphs. It happens because of missing data in that time span. We handled it by connecting consecutive data points.