### PR TITLE
[Breq 680] Arcus Containers Update Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         "click",
         "boto3",
+        "docker",
         "flake8",
         "gnocchiclient",
         "jinja2",

--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,6 @@ setup(
         "Programming Language :: Python :: 3",
         "Natural Language :: English",
     ],
-    package_data={
-        "voithos": [
-            "lib/files/grafana/*.json",
-            "lib/files/horizon/*"
-        ]
-    },
+    package_data={"voithos": ["lib/files/grafana/*.json", "lib/files/horizon/*"]},
     include_package_data=True,
 )

--- a/voithos/cli/service/arcus/api.py
+++ b/voithos/cli/service/arcus/api.py
@@ -61,10 +61,13 @@ def start(
 
 @click.option("--release", "-r", required=True, help="Version of Arcus API to run")
 @click.command(name="update")
-def update(release,):
+def update(
+    release,
+):
     """ Update arcus api """
     click.echo("Updating arcus api to version: {}".format(release))
     arcus_common.update(release, "api")
+
 
 @click.option("--host", required=True, help="MariaDB IP or FQDN")
 @click.option("--admin-user", required=True, help="Admin user for creating the new DB")

--- a/voithos/cli/service/arcus/api.py
+++ b/voithos/cli/service/arcus/api.py
@@ -4,6 +4,7 @@ import click
 
 import voithos.lib.aws.ecr as ecr
 import voithos.lib.service.arcus.api as arcus_api
+import voithos.lib.service.arcus.common as arcus_common
 import voithos.cli.service.arcus.integrations as integrations
 
 
@@ -58,6 +59,13 @@ def start(
     )
 
 
+@click.option("--release", "-r", required=True, help="Version of Arcus API to run")
+@click.command(name="update")
+def update(release,):
+    """ Update arcus api """
+    click.echo("Updating arcus api to version: {}".format(release))
+    arcus_common.update(release, "api")
+
 @click.option("--host", required=True, help="MariaDB IP or FQDN")
 @click.option("--admin-user", required=True, help="Admin user for creating the new DB")
 @click.option("--admin-pass", required=True, help="Amin user password")
@@ -95,6 +103,7 @@ def get_api_group():
 
     api_group.add_command(pull)
     api_group.add_command(start)
+    api_group.add_command(update)
     api_group.add_command(database_init)
     api_group.add_command(set_service_account)
     api_group.add_command(integrations.get_integrations_group())

--- a/voithos/cli/service/arcus/client.py
+++ b/voithos/cli/service/arcus/client.py
@@ -69,7 +69,9 @@ def start(
 
 @click.option("--release", "-r", required=True, help="Version of Arcus Client to run")
 @click.command(name="update")
-def update(release,):
+def update(
+    release,
+):
     """ Update arcus client """
     click.echo("Updating arcus client to version: {}".format(release))
     arcus_common.update(release, "client")

--- a/voithos/cli/service/arcus/client.py
+++ b/voithos/cli/service/arcus/client.py
@@ -4,6 +4,7 @@ import click
 
 import voithos.lib.aws.ecr as ecr
 import voithos.lib.service.arcus.client as arcus_client
+import voithos.lib.service.arcus.common as arcus_common
 from voithos.lib.system import error
 from voithos.constants import DEV_MODE
 
@@ -66,6 +67,14 @@ def start(
     )
 
 
+@click.option("--release", "-r", required=True, help="Version of Arcus Client to run")
+@click.command(name="update")
+def update(release,):
+    """ Update arcus client """
+    click.echo("Updating arcus client to version: {}".format(release))
+    arcus_common.update(release, "client")
+
+
 @click.command(name="rebuild")
 def rebuild():
     """ Run grunt rebuild for arcus development """
@@ -81,6 +90,7 @@ def get_client_group():
 
     client_group.add_command(pull)
     client_group.add_command(start)
+    client_group.add_command(update)
     if DEV_MODE:
         client_group.add_command(rebuild)
     return client_group

--- a/voithos/cli/service/arcus/mgr.py
+++ b/voithos/cli/service/arcus/mgr.py
@@ -6,6 +6,7 @@ import voithos.lib.aws.ecr as ecr
 import voithos.lib.service.arcus.mgr as arcus_mgr
 import voithos.lib.service.arcus.common as arcus_common
 
+
 @click.option("--release", "-r", required=True, help="Version of Arcus API to run")
 @click.command(name="pull")
 def pull(release):
@@ -63,10 +64,13 @@ def start(
 
 @click.option("--release", "-r", required=True, help="Version of Arcus Mgr to run")
 @click.command(name="update")
-def update(release,):
+def update(
+    release,
+):
     """ Update arcus mgr """
     click.echo("Updating arcus mgr to version: {}".format(release))
     arcus_common.update(release, "mgr")
+
 
 def get_mgr_group():
     """ return the arcus mgr group function """

--- a/voithos/cli/service/arcus/mgr.py
+++ b/voithos/cli/service/arcus/mgr.py
@@ -4,7 +4,7 @@ import click
 
 import voithos.lib.aws.ecr as ecr
 import voithos.lib.service.arcus.mgr as arcus_mgr
-
+import voithos.lib.service.arcus.common as arcus_common
 
 @click.option("--release", "-r", required=True, help="Version of Arcus API to run")
 @click.command(name="pull")
@@ -61,6 +61,13 @@ def start(
     )
 
 
+@click.option("--release", "-r", required=True, help="Version of Arcus Mgr to run")
+@click.command(name="update")
+def update(release,):
+    """ Update arcus mgr """
+    click.echo("Updating arcus mgr to version: {}".format(release))
+    arcus_common.update(release, "mgr")
+
 def get_mgr_group():
     """ return the arcus mgr group function """
 
@@ -70,4 +77,5 @@ def get_mgr_group():
 
     mgr_group.add_command(pull)
     mgr_group.add_command(start)
+    mgr_group.add_command(update)
     return mgr_group

--- a/voithos/lib/docker.py
+++ b/voithos/lib/docker.py
@@ -1,7 +1,8 @@
 """ Docker shell command runner """
 
-from voithos.lib.system import assert_path_exists, get_absolute_path
-
+from voithos.lib.system import assert_path_exists, get_absolute_path, error
+import docker
+import click
 
 def volume_opt(src, dest, require=True):
     """ Return a volume's argument for docker run
@@ -23,3 +24,44 @@ def env_string(env_vars):
         value = env_vars[env_var]
         env_str += f" -e {env_var}='{value}' "
     return env_str
+
+def image_exists(image_name, image_tag):
+    """ Checks if image with image_name and tag exists else throw error "Image not found" """
+    docker_client = docker.from_env()
+    arcus_image = image_name+":"+image_tag
+    image_list = docker_client.images.list()
+    for image in image_list:
+        if arcus_image in image.tags:
+            click.echo("Image {} exists.".format(arcus_image))
+            return
+    error("ERROR: Image: {} not found. Please pull {} before running update command.".format(arcus_image, arcus_image), exit=True)
+
+def get_container_inspect_info(container_name):
+    docker_client = docker.from_env()
+    _container_exists(container_name)
+    container_info = docker_client.api.inspect_container(container_name)
+    return container_info
+
+def get_container_env_variables(container_name):
+    """ Check if container exists and return container env variables """
+    container_info = get_container_inspect_info(container_name)
+    return container_info["Config"]["Env"]
+
+
+def get_container_image_tag(container_name):
+    docker_client = docker.from_env()
+    _container_exists(container_name)
+    image_tag = docker_client.api.inspect_container(container_name)["Config"]["Image"].split(":")[1]
+    return image_tag
+
+def _container_exists(container_name):
+    docker_client = docker.from_env()
+    containers_list = docker_client.containers.list()
+    exist = any(container.name == container_name for container in containers_list)
+    if not exist:
+        error("ERROR: Container: {} not found".format(container_name), exit=True)
+
+def container_action(container_name, operation, **kwargs):
+    docker_client = docker.from_env()
+    action_method = getattr(docker_client.api, operation)
+    action_method(container_name, **kwargs)

--- a/voithos/lib/docker.py
+++ b/voithos/lib/docker.py
@@ -37,24 +37,27 @@ def image_exists(image_name, image_tag):
     error("ERROR: Image: {} not found. Please pull {} before running update command.".format(arcus_image, arcus_image), exit=True)
 
 def get_container_inspect_info(container_name):
+    """  Returns container inspect info"""
     docker_client = docker.from_env()
     _container_exists(container_name)
     container_info = docker_client.api.inspect_container(container_name)
     return container_info
 
 def get_container_env_variables(container_name):
-    """ Check if container exists and return container env variables """
+    """ Checks if container exists and returns container env variables """
     container_info = get_container_inspect_info(container_name)
     return container_info["Config"]["Env"]
 
 
 def get_container_image_tag(container_name):
+    """ Returns image tag of container """
     docker_client = docker.from_env()
     _container_exists(container_name)
     image_tag = docker_client.api.inspect_container(container_name)["Config"]["Image"].split(":")[1]
     return image_tag
 
 def _container_exists(container_name):
+    """ Checks and throws error if container doesn't exist """
     docker_client = docker.from_env()
     containers_list = docker_client.containers.list()
     exist = any(container.name == container_name for container in containers_list)
@@ -62,6 +65,7 @@ def _container_exists(container_name):
         error("ERROR: Container: {} not found".format(container_name), exit=True)
 
 def container_action(container_name, operation, **kwargs):
+    """ Runs docker operations """
     docker_client = docker.from_env()
     action_method = getattr(docker_client.api, operation)
     action_method(container_name, **kwargs)

--- a/voithos/lib/docker.py
+++ b/voithos/lib/docker.py
@@ -4,12 +4,13 @@ from voithos.lib.system import assert_path_exists, get_absolute_path, error
 import docker
 import click
 
-def volume_opt(src, dest, require=True):
-    """ Return a volume's argument for docker run
 
-        Don't use volume_opt with hard-coded linux paths, it will make Windows try and mkdir in
-        C:\\WINDOWS\\system32 and fail. volume_opt can handle C:\\... syntax correctly. Instead,
-        just use '-v /linux/path:/mount/point and the docker vm on Windows will handle it.
+def volume_opt(src, dest, require=True):
+    """Return a volume's argument for docker run
+
+    Don't use volume_opt with hard-coded linux paths, it will make Windows try and mkdir in
+    C:\\WINDOWS\\system32 and fail. volume_opt can handle C:\\... syntax correctly. Instead,
+    just use '-v /linux/path:/mount/point and the docker vm on Windows will handle it.
     """
     if require:
         assert_path_exists(src)
@@ -25,16 +26,23 @@ def env_string(env_vars):
         env_str += f" -e {env_var}='{value}' "
     return env_str
 
+
 def image_exists(image_name, image_tag):
     """ Checks if image with image_name and tag exists else throw error "Image not found" """
     docker_client = docker.from_env()
-    arcus_image = image_name+":"+image_tag
+    arcus_image = image_name + ":" + image_tag
     image_list = docker_client.images.list()
     for image in image_list:
         if arcus_image in image.tags:
             click.echo("Image {} exists.".format(arcus_image))
             return
-    error("ERROR: Image: {} not found. Please pull {} before running update command.".format(arcus_image, arcus_image), exit=True)
+    error(
+        "ERROR: Image: {} not found. Please pull {} before running update command.".format(
+            arcus_image, arcus_image
+        ),
+        exit=True,
+    )
+
 
 def get_container_inspect_info(container_name):
     """  Returns container inspect info"""
@@ -42,6 +50,7 @@ def get_container_inspect_info(container_name):
     _container_exists(container_name)
     container_info = docker_client.api.inspect_container(container_name)
     return container_info
+
 
 def get_container_env_variables(container_name):
     """ Checks if container exists and returns container env variables """
@@ -56,6 +65,7 @@ def get_container_image_tag(container_name):
     image_tag = docker_client.api.inspect_container(container_name)["Config"]["Image"].split(":")[1]
     return image_tag
 
+
 def _container_exists(container_name):
     """ Checks and throws error if container doesn't exist """
     docker_client = docker.from_env()
@@ -63,6 +73,7 @@ def _container_exists(container_name):
     exist = any(container.name == container_name for container in containers_list)
     if not exist:
         error("ERROR: Container: {} not found".format(container_name), exit=True)
+
 
 def container_action(container_name, operation, **kwargs):
     """ Runs docker operations """

--- a/voithos/lib/service/arcus/client.py
+++ b/voithos/lib/service/arcus/client.py
@@ -62,7 +62,7 @@ def start(
         sys.stdout.write("TO REBUILD, EXECUTE:\n docker exec -it arcus_client grunt rebuild\n")
         dev_mount = volume_opt(client_dir, "/app")
     name = "arcus_client"
-    shell(f"docker rm -f {name} || true")
+    shell(f"docker rm -f {name} 2>/dev/null || true")
     cmd = (
         f"docker run --name {name} "
         f"{daemon} {network} {env_str} "

--- a/voithos/lib/service/arcus/common.py
+++ b/voithos/lib/service/arcus/common.py
@@ -2,8 +2,8 @@
 
 import click
 import datetime
-import voithos.lib.docker as docker
 import inspect
+import voithos.lib.docker as docker
 import voithos.lib.service.arcus.api as arcus_api
 import voithos.lib.service.arcus.client as arcus_client
 import voithos.lib.service.arcus.mgr as arcus_mgr

--- a/voithos/lib/service/arcus/common.py
+++ b/voithos/lib/service/arcus/common.py
@@ -8,21 +8,31 @@ import voithos.lib.service.arcus.api as arcus_api
 import voithos.lib.service.arcus.client as arcus_client
 import voithos.lib.service.arcus.mgr as arcus_mgr
 
+
 def update(release, arcus_service_type):
     """ Updates arcus container """
     image_name = "breqwatr/arcus-{}".format(arcus_service_type)
-    container_name = "arcus_"+arcus_service_type
+    container_name = "arcus_" + arcus_service_type
     docker.image_exists(image_name, release)
     env_variables = docker.get_container_env_variables(container_name)
     env_variables_dict = _get_env_variables_dict(env_variables)
-    args = inspect.getargspec(eval("arcus_"+arcus_service_type).start)[0]
-    args_dict = _verify_and_return_start_methods_args(release, arcus_service_type, env_variables_dict, args)
+    args = inspect.getargspec(eval("arcus_" + arcus_service_type).start)[0]
+    args_dict = _verify_and_return_start_methods_args(
+        release, arcus_service_type, env_variables_dict, args
+    )
     old_container_image_tag = docker.get_container_image_tag(container_name)
     docker.container_action(container_name, "stop")
-    arcus_rename = container_name+"_release_"+old_container_image_tag+"_datetime_"+datetime.datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")
+    arcus_rename = (
+        container_name
+        + "_release_"
+        + old_container_image_tag
+        + "_datetime_"
+        + datetime.datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")
+    )
     docker.container_action(container_name, "rename", name=arcus_rename)
     docker.container_action(arcus_rename, "update_container", restart_policy={"Name": "no"})
-    eval("arcus_"+arcus_service_type).start(**args_dict)
+    eval("arcus_" + arcus_service_type).start(**args_dict)
+
 
 def _get_env_variables_dict(env_variables):
     env_variables_dict = {}
@@ -32,61 +42,83 @@ def _get_env_variables_dict(env_variables):
         env_variables_dict[key] = value
     return env_variables_dict
 
+
 def _verify_and_return_start_methods_args(release, arcus_service_type, env_variables_dict, args):
     args_dict = {}
     if arcus_service_type == "api":
-        args_dict = { "release": release,
-                      "fqdn": env_variables_dict["OPENSTACK_VIP"],
-                      "rabbit_pass": env_variables_dict["RABBITMQ_PASSWORD"],
-                      "rabbit_ips_list": env_variables_dict["RABBIT_IPS_CSV"].split(","),
-                      "sql_ip": env_variables_dict["SQL_IP"],
-                      "sql_password": env_variables_dict["SQL_PASSWORD"],
-                      "https": env_variables_dict["HTTPS_OPENSTACK_APIS"],
-                      "port": env_variables_dict["ARCUS_API_PORT"],
-                      "secret": env_variables_dict["ARCUS_INTEGRATION_SECRET"] }
+        args_dict = {
+            "release": release,
+            "fqdn": env_variables_dict["OPENSTACK_VIP"],
+            "rabbit_pass": env_variables_dict["RABBITMQ_PASSWORD"],
+            "rabbit_ips_list": env_variables_dict["RABBIT_IPS_CSV"].split(","),
+            "sql_ip": env_variables_dict["SQL_IP"],
+            "sql_password": env_variables_dict["SQL_PASSWORD"],
+            "https": env_variables_dict["HTTPS_OPENSTACK_APIS"],
+            "port": env_variables_dict["ARCUS_API_PORT"],
+            "secret": env_variables_dict["ARCUS_INTEGRATION_SECRET"],
+        }
     if arcus_service_type == "client":
         cert_paths = _get_cert_paths(arcus_service_type)
-        cert_path = None if "/etc/nginx/haproxy.crt" not in cert_paths else cert_paths["/etc/nginx/haproxy.crt"]
-        cert_key_path = None if "/etc/nginx/haproxy.key" not in cert_paths else cert_paths["/etc/nginx/haproxy.key"]
-        args_dict = {"release": release,
-                      "api_ip": env_variables_dict["ARCUS_API_IP"],
-                      "openstack_ip": env_variables_dict["OPENSTACK_VIP"],
-                      "glance_https": env_variables_dict["GLANCE_HTTPS"],
-                      "arcus_https": env_variables_dict["ARCUS_USE_HTTPS"],
-                      "cert_path": cert_path,
-                      "cert_key_path": cert_key_path,
-                      "http_port": env_variables_dict["ARCUS_CLIENT_HTTP_PORT"],
-                      "https_port": env_variables_dict["ARCUS_CLIENT_HTTPS_PORT"]  }
+        cert_path = (
+            None
+            if "/etc/nginx/haproxy.crt" not in cert_paths
+            else cert_paths["/etc/nginx/haproxy.crt"]
+        )
+        cert_key_path = (
+            None
+            if "/etc/nginx/haproxy.key" not in cert_paths
+            else cert_paths["/etc/nginx/haproxy.key"]
+        )
+        args_dict = {
+            "release": release,
+            "api_ip": env_variables_dict["ARCUS_API_IP"],
+            "openstack_ip": env_variables_dict["OPENSTACK_VIP"],
+            "glance_https": env_variables_dict["GLANCE_HTTPS"],
+            "arcus_https": env_variables_dict["ARCUS_USE_HTTPS"],
+            "cert_path": cert_path,
+            "cert_key_path": cert_key_path,
+            "http_port": env_variables_dict["ARCUS_CLIENT_HTTP_PORT"],
+            "https_port": env_variables_dict["ARCUS_CLIENT_HTTPS_PORT"],
+        }
 
     if arcus_service_type == "mgr":
         kolla_dir_path = _get_kolla_dir(arcus_service_type)
-        args_dict = { "release": release,
-                      "openstack_vip": env_variables_dict["OPENSTACK_VIP"],
-                      "sql_pass": env_variables_dict["SQL_PASSWORD"],
-                      "sql_ip": env_variables_dict["SQL_IP"],
-                      "rabbit_ips_list": env_variables_dict["RABBIT_NODES_CSV"].split(","),
-                      "rabbit_pass": env_variables_dict["RABBIT_PASSWORD"],
-                      "enable_ceph": env_variables_dict["ENABLE_CEPH"],
-                      "kolla_ansible_dir": kolla_dir_path,
-                      "cloud_name": env_variables_dict["CLOUD_NAME"] }
+        args_dict = {
+            "release": release,
+            "openstack_vip": env_variables_dict["OPENSTACK_VIP"],
+            "sql_pass": env_variables_dict["SQL_PASSWORD"],
+            "sql_ip": env_variables_dict["SQL_IP"],
+            "rabbit_ips_list": env_variables_dict["RABBIT_NODES_CSV"].split(","),
+            "rabbit_pass": env_variables_dict["RABBIT_PASSWORD"],
+            "enable_ceph": env_variables_dict["ENABLE_CEPH"],
+            "kolla_ansible_dir": kolla_dir_path,
+            "cloud_name": env_variables_dict["CLOUD_NAME"],
+        }
     for key in args_dict:
         args.remove(key)
-    if len(args) >  0:
-        msg = "ERROR: New args {} aren't supported in running arcus_{} container. Please create new arcus_{} container.".format(args, arcus_service_type)
+    if len(args) > 0:
+        msg = "ERROR: New args {} aren't supported in running arcus_{} container. Please create new arcus_{} container.".format(
+            args, arcus_service_type
+        )
         error(msg, exit=True)
     return args_dict
 
 
 def _get_cert_paths(arcus_service_type):
-    bind_list = docker.get_container_inspect_info("arcus_"+arcus_service_type)["HostConfig"]["Binds"]
+    bind_list = docker.get_container_inspect_info("arcus_" + arcus_service_type)["HostConfig"][
+        "Binds"
+    ]
     cert_paths = {}
     for bind in bind_list:
         if "/etc/nginx/haproxy" in bind:
             cert_paths[bind.split(":")[1]] = bind.split(":")[0]
     return cert_paths
 
+
 def _get_kolla_dir(arcus_service_type):
-    bind_list = docker.get_container_inspect_info("arcus_"+arcus_service_type)["HostConfig"]["Binds"]
+    bind_list = docker.get_container_inspect_info("arcus_" + arcus_service_type)["HostConfig"][
+        "Binds"
+    ]
     cert_paths = {}
     for bind in bind_list:
         if ":/etc/kolla" in bind:

--- a/voithos/lib/service/arcus/common.py
+++ b/voithos/lib/service/arcus/common.py
@@ -1,0 +1,93 @@
+""" lib for arcus services """
+
+import click
+import datetime
+import voithos.lib.docker as docker
+import inspect
+import voithos.lib.service.arcus.api as arcus_api
+import voithos.lib.service.arcus.client as arcus_client
+import voithos.lib.service.arcus.mgr as arcus_mgr
+
+def update(release, arcus_service_type):
+    """ Updates arcus container """
+    image_name = "breqwatr/arcus-{}".format(arcus_service_type)
+    container_name = "arcus_"+arcus_service_type
+    docker.image_exists(image_name, release)
+    env_variables = docker.get_container_env_variables(container_name)
+    env_variables_dict = _get_env_variables_dict(env_variables)
+    args = inspect.getargspec(eval("arcus_"+arcus_service_type).start)[0]
+    args_dict = _verify_and_return_start_methods_args(release, arcus_service_type, env_variables_dict, args)
+    old_container_image_tag = docker.get_container_image_tag(container_name)
+    docker.container_action(container_name, "stop")
+    arcus_rename = container_name+"_release_"+old_container_image_tag+"_datetime_"+datetime.datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")
+    docker.container_action(container_name, "rename", name=arcus_rename)
+    docker.container_action(arcus_rename, "update_container", restart_policy={"Name": "no"})
+    eval("arcus_"+arcus_service_type).start(**args_dict)
+
+def _get_env_variables_dict(env_variables):
+    env_variables_dict = {}
+    for env_variable in env_variables:
+        key = env_variable.split("=")[0]
+        value = env_variable.split("=")[1]
+        env_variables_dict[key] = value
+    return env_variables_dict
+
+def _verify_and_return_start_methods_args(release, arcus_service_type, env_variables_dict, args):
+    args_dict = {}
+    if arcus_service_type == "api":
+        args_dict = { "release": release,
+                      "fqdn": env_variables_dict["OPENSTACK_VIP"],
+                      "rabbit_pass": env_variables_dict["RABBITMQ_PASSWORD"],
+                      "rabbit_ips_list": env_variables_dict["RABBIT_IPS_CSV"].split(","),
+                      "sql_ip": env_variables_dict["SQL_IP"],
+                      "sql_password": env_variables_dict["SQL_PASSWORD"],
+                      "https": env_variables_dict["HTTPS_OPENSTACK_APIS"],
+                      "port": env_variables_dict["ARCUS_API_PORT"],
+                      "secret": env_variables_dict["ARCUS_INTEGRATION_SECRET"] }
+    if arcus_service_type == "client":
+        cert_paths = _get_cert_paths(arcus_service_type)
+        cert_path = None if "/etc/nginx/haproxy.crt" not in cert_paths else cert_paths["/etc/nginx/haproxy.crt"]
+        cert_key_path = None if "/etc/nginx/haproxy.key" not in cert_paths else cert_paths["/etc/nginx/haproxy.key"]
+        args_dict = {"release": release,
+                      "api_ip": env_variables_dict["ARCUS_API_IP"],
+                      "openstack_ip": env_variables_dict["OPENSTACK_VIP"],
+                      "glance_https": env_variables_dict["GLANCE_HTTPS"],
+                      "arcus_https": env_variables_dict["ARCUS_USE_HTTPS"],
+                      "cert_path": cert_path,
+                      "cert_key_path": cert_key_path,
+                      "http_port": env_variables_dict["ARCUS_CLIENT_HTTP_PORT"],
+                      "https_port": env_variables_dict["ARCUS_CLIENT_HTTPS_PORT"]  }
+
+    if arcus_service_type == "mgr":
+        kolla_dir_path = _get_kolla_dir(arcus_service_type)
+        args_dict = { "release": release,
+                      "openstack_vip": env_variables_dict["OPENSTACK_VIP"],
+                      "sql_pass": env_variables_dict["SQL_PASSWORD"],
+                      "sql_ip": env_variables_dict["SQL_IP"],
+                      "rabbit_ips_list": env_variables_dict["RABBIT_NODES_CSV"].split(","),
+                      "rabbit_pass": env_variables_dict["RABBIT_PASSWORD"],
+                      "enable_ceph": env_variables_dict["ENABLE_CEPH"],
+                      "kolla_ansible_dir": kolla_dir_path,
+                      "cloud_name": env_variables_dict["CLOUD_NAME"] }
+    for key in args_dict:
+        args.remove(key)
+    if len(args) >  0:
+        msg = "ERROR: New args {} aren't supported in running arcus_{} container. Please create new arcus_{} container.".format(args, arcus_service_type)
+        error(msg, exit=True)
+    return args_dict
+
+
+def _get_cert_paths(arcus_service_type):
+    bind_list = docker.get_container_inspect_info("arcus_"+arcus_service_type)["HostConfig"]["Binds"]
+    cert_paths = {}
+    for bind in bind_list:
+        if "/etc/nginx/haproxy" in bind:
+            cert_paths[bind.split(":")[1]] = bind.split(":")[0]
+    return cert_paths
+
+def _get_kolla_dir(arcus_service_type):
+    bind_list = docker.get_container_inspect_info("arcus_"+arcus_service_type)["HostConfig"]["Binds"]
+    cert_paths = {}
+    for bind in bind_list:
+        if ":/etc/kolla" in bind:
+            return bind.split(":")[0]


### PR DESCRIPTION
This PR addresses #680. After this PR is merged, arcus containers can be upgraded using voithos cli. This feature won't work if:
- New environment variables are introduced in newer version of arcus services.
- New arguments are introduced in `arcus <service-name> start` commands.

In above mentioned two cases. Either we have to upgrade manually or revisit this issue.