### PR TITLE
[BREQ 1040] Voithos docs changes ceilometer

### DIFF
--- a/docs/openstack-kolla-config.md
+++ b/docs/openstack-kolla-config.md
@@ -40,7 +40,6 @@ sources:
         - cpu
         - memory.usage
         - volume.size
-        - compute.instance.booting.time
 ```
 
 
@@ -59,7 +58,11 @@ The `pipeline.yaml` file configures Ceilometer to the the custom metering policy
 sources:
     - name: meter_source
       meters:
-          - "*"
+          - cpu
+          - vcpus
+          - memory
+          - memory.usage
+          - volume.size
       sinks:
           - meter_sink
 sinks:


### PR DESCRIPTION
This PR addresses part of #1040. Configs for only creating/polling metrics that are required by usage api.