### PR TITLE
Corrected a typo under "Active Directory uses the following object cl…

### DIFF
--- a/docs/openstack-kolla-config.md
+++ b/docs/openstack-kolla-config.md
@@ -322,7 +322,7 @@ user_enabled_invert = false
 user_enabled_default = 512
 group_id_attribute = cn
 group_name_attribute = ou
-group_member_attribut = member
+group_member_attribute = member
 group_desc_attribute = description
 
 # In big domains with nested OUs you may also need:


### PR DESCRIPTION
…asses & attributes"

Corrected a typo missing "e" at the end of parameter "group_member_attribute"