### PR TITLE
[Breq 1163] Python version dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     download_url="https://github.com/breqwatr/voithos/archive/1.00.tar.gz",
     url="https://github.com/breqwatr/voithos",
     keywords=["Breqwatr", "Openstack", "Kolla", "Ceph", "Docker"],
+    python_requires='>=3.0.0',
     install_requires=[
         "click",
         "boto3",


### PR DESCRIPTION
This PR addresses #1163. After this PR is merged, voithos will require python version >= 3.0.0.