### PR TITLE
[Breq 1168][Breq 1371] Repo preference for image pull and single image pull bug

### DIFF
--- a/voithos/cli/config.py
+++ b/voithos/cli/config.py
@@ -19,6 +19,17 @@ def license(new_key):
         click.echo("No license found: Use --set to configure the key")
 
 
+@click.option(
+    "--prefer-ecr/--prefer-dhub", "prefer_ecr", default=None, help="Pull image from ecr or dockerhub?"
+)
+@click.command()
+def set(prefer_ecr):
+    """ Apply config options"""
+    if prefer_ecr is not None:
+       repo_type = "ecr" if prefer_ecr else "dockerhub"
+       click.echo("Setting the prefered repo type to {}".format(repo_type))
+       config.set_repo_type(repo_type)
+
 def get_config_group():
     """ Return the config click group """
 
@@ -27,4 +38,5 @@ def get_config_group():
         """ Configure Voithos """
 
     config_group.add_command(license)
+    config_group.add_command(set)
     return config_group

--- a/voithos/cli/util/util.py
+++ b/voithos/cli/util/util.py
@@ -68,7 +68,9 @@ def create_and_upload_voithos_tar(voithos_branch):
 @click.command(name="export-offline-image")
 def export_offline_single_image(name, tag, path, force):
     """ Download single image at <path>/images/ """
-    util.verify_create_dirs(path)
+    if not os.path.isdir(path):
+        echo("Creating base directory: {}".format(path))
+        os.mkdir(path)
     util.pull_and_save_single_image(name, tag, path, force)
 
 

--- a/voithos/lib/config.py
+++ b/voithos/lib/config.py
@@ -34,6 +34,16 @@ def set_config(key, value):
     system.set_file_contents(config_path, config_json)
 
 
+
+def get_repo_type():
+    """ Return prefered repo type """
+    config = get_config()
+    if "repo-type" in config:
+        return config["repo-type"]
+    else:
+        return "dockerhub"
+
+
 def get_license():
     """ Return the license key - Return an empty string if not found """
     config = get_config()
@@ -50,3 +60,8 @@ def require_license():
 def set_license(license):
     """ Save the given license key to the config """
     set_config("license", license)
+
+
+def set_repo_type(repo_type):
+    """ Save the repo type to the config """
+    set_config("repo-type", repo_type)


### PR DESCRIPTION
This PR addresses #1168 and #1371.
After merging this PR, we can set the repo from which we want to pull images e.g ecr and dockerhub.
Commands to set preference are `voithos config set --prefer-ecr`  or `voithos config set --prefer-dhub`.

This PR will also fix a bug. When we download a single image(offline install) to a path, it creates an empty `images` directory along with the image.